### PR TITLE
Add communication class for use with Xbee

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,10 @@ python:
 
 # command to install dependencies
 install:
-  - pip install pipenv
+  - pip install pipenv flake8
   - make init
 
 # command to run tests
 script:
-  - make test
+  - make test-all
+  - flake8 --max-line-length=99 .

--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,8 @@ name = "pypi"
 
 mock = "*"
 dronekit-sitl = "*"
+pytest = "*"
+"e1839a8" = {path = ".", editable = true}
 
 
 [packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,20 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9518e681f41df36ce2cc88f4b93afb06d2b1edea70ca1d8321d5204c5f596867"
-        },
-        "host-environment-markers": {
-            "implementation_name": "cpython",
-            "implementation_version": "0",
-            "os_name": "posix",
-            "platform_machine": "x86_64",
-            "platform_python_implementation": "CPython",
-            "platform_release": "4.15.6-1-ARCH",
-            "platform_system": "Linux",
-            "platform_version": "#1 SMP PREEMPT Sun Feb 25 12:53:23 UTC 2018",
-            "python_full_version": "2.7.14",
-            "python_version": "2.7",
-            "sys_platform": "linux2"
+            "sha256": "563089ebf3e2dede04cb50ecc9aca2d44d4f103fc6228219ae9a80bdcbd83836"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -31,9 +18,9 @@
     "default": {
         "dronekit": {
             "hashes": [
-                "sha256:d8f0d67516940349983ceb73d84e2be19b41ed4e276d3a464b53f1c07e617699",
+                "sha256:8bc3796a10049fd1a832bab15c092f04cd843ce0013a85a0b188d9b6ce3f734e",
                 "sha256:91c19b4559ae536f2020c4e77bb16ac977a7ca7a6e43b7392acef6061cebf578",
-                "sha256:8bc3796a10049fd1a832bab15c092f04cd843ce0013a85a0b188d9b6ce3f734e"
+                "sha256:d8f0d67516940349983ceb73d84e2be19b41ed4e276d3a464b53f1c07e617699"
             ],
             "version": "==2.9.1"
         },
@@ -64,46 +51,53 @@
         },
         "pyserial": {
             "hashes": [
-                "sha256:e0770fadba80c31013896c7e6ef703f72e7834965954a78e71a3049488d4d7d8",
-                "sha256:6e2d401fdee0eab996cf734e67773a0143b932772ca8b42451440cfed942c627"
+                "sha256:6e2d401fdee0eab996cf734e67773a0143b932772ca8b42451440cfed942c627",
+                "sha256:e0770fadba80c31013896c7e6ef703f72e7834965954a78e71a3049488d4d7d8"
             ],
             "version": "==3.4"
         },
         "pyzmq": {
             "hashes": [
-                "sha256:2fb4d745ffe0a65ebf8fd29df093bb5c0ac96a506cb05b9a7b7c94b2524ae7f6",
-                "sha256:b89268020a843d4c3cc04180577ec061fe96d35f267b0b672cb006e4d70560da",
-                "sha256:d51eb3902d27d691483243707bfa67972167a70269bbbc172b74eeac4f780a1d",
-                "sha256:e5578ae84bb94e97adadfcb00106a1cb161cb8017f89b01f6c3737f356257811",
-                "sha256:4193cc666591495ab7fe8d24fa8374a35f9775f16dc7c46e03615559e1fc1855",
-                "sha256:b328c538061757f627d32f7f8885c16f1d2f59f5374e057822f3c8e6cd94c41b",
+                "sha256:0145ae59139b41f65e047a3a9ed11bbc36e37d5e96c64382fcdff911c4d8c3f0",
                 "sha256:18de8a02768b1c0b3495ac635b24bd902fafc08befb70a6e68c4d343ccbd6cbd",
-                "sha256:fb983aec4bddee3680a0b7395f99e4595d70d81841370da736c5dc642bad4cd2",
-                "sha256:ad5a8b19b6671b52d30ccfc3a0f4c600e49c4e2dcc88caf4106ed5958dec8d5e",
-                "sha256:767e1d0b1f7fff1950127abc08c5a5af2754987bc6480c6d641bed6971278a7a",
-                "sha256:c30d27c9b35285597b8ef3019f97b9b98457b053f65dcc87a90dfdd4db09ca78",
-                "sha256:bdb12b485b3440b5193cd337d27cc126cdfc54ea9f38df237e1ead6216435cbe",
-                "sha256:ba0b43aebf856e5e249250d74c1232d6600b6859328920d12e2ba72a565ab1b1",
-                "sha256:630fb21f7474eb9e409a1ad476bf1ec489a69eb021172d422f2485cc3a44cd79",
-                "sha256:6c3632d2c17cf03ce728ffaa328d45bb053623b3a0aa9747adcde81778d5a4d5",
+                "sha256:2fb4d745ffe0a65ebf8fd29df093bb5c0ac96a506cb05b9a7b7c94b2524ae7f6",
+                "sha256:4193cc666591495ab7fe8d24fa8374a35f9775f16dc7c46e03615559e1fc1855",
+                "sha256:445fed4d71ac48da258ba38f2e29c88c5091124212a4004a0a6a42e6586a7de1",
                 "sha256:538dfdd9542cf9ff37cd958da03b58d56b53b90800159ea07adc51a8ec7ffcb8",
                 "sha256:613ac1fc4591b1c6a0a52ce3ed17dbffd6a17e985df504e8b4cdb987f97285b1",
-                "sha256:a0ecf4c3eccd92f030a4e3e334b9da6fa3ee86be00249343c74e476d70567d0f",
+                "sha256:630fb21f7474eb9e409a1ad476bf1ec489a69eb021172d422f2485cc3a44cd79",
+                "sha256:6c3632d2c17cf03ce728ffaa328d45bb053623b3a0aa9747adcde81778d5a4d5",
+                "sha256:767e1d0b1f7fff1950127abc08c5a5af2754987bc6480c6d641bed6971278a7a",
                 "sha256:863ec1bfa52da6eaa5c4aa59143eeaeb4ef7a076862407a548ec645f25e6d6df",
-                "sha256:f35b4cdeffff79357a9d929daa2a8620fb362b2cbeebdc5dd2cf9fcd27c44821",
-                "sha256:445fed4d71ac48da258ba38f2e29c88c5091124212a4004a0a6a42e6586a7de1",
+                "sha256:a0ecf4c3eccd92f030a4e3e334b9da6fa3ee86be00249343c74e476d70567d0f",
+                "sha256:ad5a8b19b6671b52d30ccfc3a0f4c600e49c4e2dcc88caf4106ed5958dec8d5e",
                 "sha256:b31f2b50ad2920f21b904f5edf66bee324e42bb978df1407ecf381b210d4678e",
-                "sha256:0145ae59139b41f65e047a3a9ed11bbc36e37d5e96c64382fcdff911c4d8c3f0"
+                "sha256:b328c538061757f627d32f7f8885c16f1d2f59f5374e057822f3c8e6cd94c41b",
+                "sha256:b89268020a843d4c3cc04180577ec061fe96d35f267b0b672cb006e4d70560da",
+                "sha256:ba0b43aebf856e5e249250d74c1232d6600b6859328920d12e2ba72a565ab1b1",
+                "sha256:bdb12b485b3440b5193cd337d27cc126cdfc54ea9f38df237e1ead6216435cbe",
+                "sha256:c30d27c9b35285597b8ef3019f97b9b98457b053f65dcc87a90dfdd4db09ca78",
+                "sha256:d51eb3902d27d691483243707bfa67972167a70269bbbc172b74eeac4f780a1d",
+                "sha256:e5578ae84bb94e97adadfcb00106a1cb161cb8017f89b01f6c3737f356257811",
+                "sha256:f35b4cdeffff79357a9d929daa2a8620fb362b2cbeebdc5dd2cf9fcd27c44821",
+                "sha256:fb983aec4bddee3680a0b7395f99e4595d70d81841370da736c5dc642bad4cd2"
             ],
             "version": "==17.0.0"
         }
     },
     "develop": {
+        "attrs": {
+            "hashes": [
+                "sha256:1c7960ccfd6a005cd9f7ba884e6316b5e430a3f1a6c37c5f87d8b43f83b54ec9",
+                "sha256:a17a9573a6f475c99b551c0e0a812707ddda1ec9653bed04c13841404ed6f450"
+            ],
+            "version": "==17.4.0"
+        },
         "dronekit": {
             "hashes": [
-                "sha256:d8f0d67516940349983ceb73d84e2be19b41ed4e276d3a464b53f1c07e617699",
+                "sha256:8bc3796a10049fd1a832bab15c092f04cd843ce0013a85a0b188d9b6ce3f734e",
                 "sha256:91c19b4559ae536f2020c4e77bb16ac977a7ca7a6e43b7392acef6061cebf578",
-                "sha256:8bc3796a10049fd1a832bab15c092f04cd843ce0013a85a0b188d9b6ce3f734e"
+                "sha256:d8f0d67516940349983ceb73d84e2be19b41ed4e276d3a464b53f1c07e617699"
             ],
             "version": "==2.9.1"
         },
@@ -113,12 +107,16 @@
             ],
             "version": "==3.2.0"
         },
+        "e1839a8": {
+            "editable": true,
+            "path": "."
+        },
         "funcsigs": {
             "hashes": [
                 "sha256:330cc27ccbf7f1e992e69fef78261dc7c6569012cf397db8d3de0234e6c937ca",
                 "sha256:a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50"
             ],
-            "markers": "python_version < '3.3'",
+            "markers": "python_version < '3.0'",
             "version": "==1.0.2"
         },
         "future": {
@@ -143,24 +141,37 @@
         },
         "pbr": {
             "hashes": [
-                "sha256:60c25b7dfd054ef9bb0ae327af949dd4676aa09ac3a9471cdc871d8a9213f9ac",
-                "sha256:05f61c71aaefc02d8e37c0a3eeb9815ff526ea28b3b76324769e6158d7f95be1"
+                "sha256:05f61c71aaefc02d8e37c0a3eeb9815ff526ea28b3b76324769e6158d7f95be1",
+                "sha256:60c25b7dfd054ef9bb0ae327af949dd4676aa09ac3a9471cdc871d8a9213f9ac"
             ],
             "version": "==3.1.1"
         },
+        "pluggy": {
+            "hashes": [
+                "sha256:7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff"
+            ],
+            "version": "==0.6.0"
+        },
         "psutil": {
             "hashes": [
-                "sha256:82a06785db8eeb637b349006cc28a92e40cd190fefae9875246d18d0de7ccac8",
-                "sha256:4152ae231709e3e8b80e26b6da20dc965a1a589959c48af1ed024eca6473f60d",
                 "sha256:230eeb3aeb077814f3a2cd036ddb6e0f571960d327298cc914c02385c3e02a63",
-                "sha256:a3286556d4d2f341108db65d8e20d0cd3fcb9a91741cb5eb496832d7daf2a97c",
-                "sha256:94d4e63189f2593960e73acaaf96be235dd8a455fe2bcb37d8ad6f0e87f61556",
-                "sha256:c91eee73eea00df5e62c741b380b7e5b6fdd553891bee5669817a3a38d036f13",
+                "sha256:4152ae231709e3e8b80e26b6da20dc965a1a589959c48af1ed024eca6473f60d",
                 "sha256:779ec7e7621758ca11a8d99a1064996454b3570154277cc21342a01148a49c28",
+                "sha256:82a06785db8eeb637b349006cc28a92e40cd190fefae9875246d18d0de7ccac8",
                 "sha256:8a15d773203a1277e57b1d11a7ccdf70804744ef4a9518a87ab8436995c31a4b",
+                "sha256:94d4e63189f2593960e73acaaf96be235dd8a455fe2bcb37d8ad6f0e87f61556",
+                "sha256:a3286556d4d2f341108db65d8e20d0cd3fcb9a91741cb5eb496832d7daf2a97c",
+                "sha256:c91eee73eea00df5e62c741b380b7e5b6fdd553891bee5669817a3a38d036f13",
                 "sha256:e2467e9312c2fa191687b89ff4bc2ad8843be4af6fb4dc95a7cc5f7d7a327b18"
             ],
             "version": "==5.4.3"
+        },
+        "py": {
+            "hashes": [
+                "sha256:8cca5c229d225f8c1e3085be4fcf306090b00850fefad892f9d96c7b6e2f310f",
+                "sha256:ca18943e28235417756316bfada6cd96b23ce60dd532642690dcfdaba988a76d"
+            ],
+            "version": "==1.5.2"
         },
         "pymavlink": {
             "hashes": [
@@ -168,10 +179,58 @@
             ],
             "version": "==2.0.6"
         },
+        "pynmea2": {
+            "hashes": [
+                "sha256:f1509fe9a424f2ff0547a0b8475f807a587e3482eb6aed6b873c3df590edbca0"
+            ],
+            "version": "==1.12.0"
+        },
+        "pyserial": {
+            "hashes": [
+                "sha256:6e2d401fdee0eab996cf734e67773a0143b932772ca8b42451440cfed942c627",
+                "sha256:e0770fadba80c31013896c7e6ef703f72e7834965954a78e71a3049488d4d7d8"
+            ],
+            "version": "==3.4"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:062027955bccbc04d2fcd5d79690947e018ba31abe4c90b2c6721abec734261b",
+                "sha256:117bad36c1a787e1a8a659df35de53ba05f9f3398fb9e4ac17e80ad5903eb8c5"
+            ],
+            "version": "==3.4.2"
+        },
+        "pyzmq": {
+            "hashes": [
+                "sha256:0145ae59139b41f65e047a3a9ed11bbc36e37d5e96c64382fcdff911c4d8c3f0",
+                "sha256:18de8a02768b1c0b3495ac635b24bd902fafc08befb70a6e68c4d343ccbd6cbd",
+                "sha256:2fb4d745ffe0a65ebf8fd29df093bb5c0ac96a506cb05b9a7b7c94b2524ae7f6",
+                "sha256:4193cc666591495ab7fe8d24fa8374a35f9775f16dc7c46e03615559e1fc1855",
+                "sha256:445fed4d71ac48da258ba38f2e29c88c5091124212a4004a0a6a42e6586a7de1",
+                "sha256:538dfdd9542cf9ff37cd958da03b58d56b53b90800159ea07adc51a8ec7ffcb8",
+                "sha256:613ac1fc4591b1c6a0a52ce3ed17dbffd6a17e985df504e8b4cdb987f97285b1",
+                "sha256:630fb21f7474eb9e409a1ad476bf1ec489a69eb021172d422f2485cc3a44cd79",
+                "sha256:6c3632d2c17cf03ce728ffaa328d45bb053623b3a0aa9747adcde81778d5a4d5",
+                "sha256:767e1d0b1f7fff1950127abc08c5a5af2754987bc6480c6d641bed6971278a7a",
+                "sha256:863ec1bfa52da6eaa5c4aa59143eeaeb4ef7a076862407a548ec645f25e6d6df",
+                "sha256:a0ecf4c3eccd92f030a4e3e334b9da6fa3ee86be00249343c74e476d70567d0f",
+                "sha256:ad5a8b19b6671b52d30ccfc3a0f4c600e49c4e2dcc88caf4106ed5958dec8d5e",
+                "sha256:b31f2b50ad2920f21b904f5edf66bee324e42bb978df1407ecf381b210d4678e",
+                "sha256:b328c538061757f627d32f7f8885c16f1d2f59f5374e057822f3c8e6cd94c41b",
+                "sha256:b89268020a843d4c3cc04180577ec061fe96d35f267b0b672cb006e4d70560da",
+                "sha256:ba0b43aebf856e5e249250d74c1232d6600b6859328920d12e2ba72a565ab1b1",
+                "sha256:bdb12b485b3440b5193cd337d27cc126cdfc54ea9f38df237e1ead6216435cbe",
+                "sha256:c30d27c9b35285597b8ef3019f97b9b98457b053f65dcc87a90dfdd4db09ca78",
+                "sha256:d51eb3902d27d691483243707bfa67972167a70269bbbc172b74eeac4f780a1d",
+                "sha256:e5578ae84bb94e97adadfcb00106a1cb161cb8017f89b01f6c3737f356257811",
+                "sha256:f35b4cdeffff79357a9d929daa2a8620fb362b2cbeebdc5dd2cf9fcd27c44821",
+                "sha256:fb983aec4bddee3680a0b7395f99e4595d70d81841370da736c5dc642bad4cd2"
+            ],
+            "version": "==17.0.0"
+        },
         "six": {
             "hashes": [
-                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb",
-                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
             ],
             "version": "==1.11.0"
         }

--- a/control/__version__.py
+++ b/control/__version__.py
@@ -1,0 +1,4 @@
+"""Defines the current package version."""
+VERSION = (0, 0, 0)
+
+__version__ = '.'.join(map(str, VERSION))

--- a/control/communication.py
+++ b/control/communication.py
@@ -1,0 +1,39 @@
+"""Abstracts communication using the Xbee."""
+import json
+import serial
+
+
+class Communication:
+    """Class abstracting communication using the Xbee via serial."""
+    def __init__(self, port):
+        self.ser = serial.Serial(port)
+
+    def send(self, data):
+        """Send data via the communication module.
+
+        This functions sends the data via serial. It is important that the data
+        be "jsonnable" or else this will fail miserably.
+
+        :param data: The data to send (must be able to be jsonned).
+
+        """
+        jsoned = json.dumps(data)
+        byte_data = str.encode(jsoned)
+        self.ser.write(byte_data)
+        self.ser.write(b'\n')
+
+    def receive(self):
+        """Receive data from the communcation module.
+
+        This function is currently blocking until data has been received. The
+        type of data returned should be the same as the type that was sent by
+        the other device.
+
+        :returns: original data -- This data has the type that was sent. It is
+                                   up to the user to determine the type and use
+                                   it accordingly.
+
+        """
+        jsoned_data = self.ser.readline()
+        unjsoned_data = json.loads(jsoned_data)
+        return unjsoned_data

--- a/examples/gpsread.py
+++ b/examples/gpsread.py
@@ -1,8 +1,5 @@
 """Reads 10 gps outputs from the serial connection"""
-import os
 import pprint
-import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 import control.gps
 
 

--- a/makefile
+++ b/makefile
@@ -1,5 +1,16 @@
+.PHONY: test test-component test-all init clean all
+
+test:
+	pipenv run pytest tests/unit
+
+test-component:
+	pipenv run pytest tests/component
+
+test-all:
+	pipenv run pytest tests
+
 init:
 	pipenv install --dev
 
-test:
-	pipenv run python -m unittest discover tests/
+clean:
+	rm -rf control.egg-info .pytest_cache */*.pyc */__pycache__

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Note: To use the 'upload' functionality of this file, you must:
+#   $ pip install twine
+
+import io
+import os
+import sys
+from shutil import rmtree
+
+from setuptools import find_packages, setup, Command
+
+# Package meta-data.
+NAME = 'control'
+DESCRIPTION = 'A dronekit application for collecting data from UAVs'
+URL = 'https://github.com/team204/control'
+EMAIL = 'ajhalaney@gmail.com'
+AUTHOR = 'Andrew Halaney'
+REQUIRES_PYTHON = '>=2.7.0, <3.0'
+VERSION = None
+
+# What packages are required for this module to be executed?
+REQUIRED = [
+    'pytest', 'dronekit', 'pyserial', 'pynmea2', 'dronekit-sitl', 'pyzmq'
+]
+
+# The rest you shouldn't have to touch too much :)
+# ------------------------------------------------
+# Except, perhaps the License and Trove Classifiers!
+# If you do change the License, remember to change the Trove Classifier
+# for that!
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+# Import the README and use it as the long-description.
+# Note: this will only work if 'README.rst'
+# is present in your MANIFEST.in file!
+with io.open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
+    long_description = '\n' + f.read()
+
+# Load the package's __version__.py module as a dictionary.
+about = {}
+if not VERSION:
+    with open(os.path.join(here, NAME, '__version__.py')) as f:
+        exec(f.read(), about)
+else:
+    about['__version__'] = VERSION
+
+
+class UploadCommand(Command):
+    """Support setup.py upload."""
+
+    description = 'Build and publish the package.'
+    user_options = []
+
+    @staticmethod
+    def status(s):
+        """Prints things in bold."""
+        print('\033[1m{0}\033[0m'.format(s))
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        try:
+            self.status('Removing previous builds…')
+            rmtree(os.path.join(here, 'dist'))
+        except OSError:
+            pass
+
+        self.status('Building Source and Wheel (universal) distribution…')
+        os.system('{0} setup.py sdist bdist_wheel --universal'
+                  .format(sys.executable))
+
+        self.status('Uploading the package to PyPi via Twine…')
+        os.system('twine upload dist/*')
+
+        self.status('Pushing git tags…')
+        os.system('git tag v{0}'.format(about['__version__']))
+        os.system('git push --tags')
+
+        sys.exit()
+
+
+# Where the magic happens:
+setup(
+    name=NAME,
+    version=about['__version__'],
+    description=DESCRIPTION,
+    long_description=long_description,
+    author=AUTHOR,
+    author_email=EMAIL,
+    python_requires=REQUIRES_PYTHON,
+    url=URL,
+    packages=find_packages(exclude=('tests',)),
+    # If your package is a single module, use this instead of 'packages':
+    # py_modules=['mypackage'],
+
+    # entry_points={
+    #     'console_scripts': ['mycli=mymodule:cli'],
+    # },
+    install_requires=REQUIRED,
+    include_package_data=True,
+    license='MIT',
+    classifiers=[
+        # Trove classifiers
+        # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy'
+    ],
+    # $ setup.py publish support.
+    cmdclass={
+        'upload': UploadCommand,
+    },
+)

--- a/tests/component/test_simulator.py
+++ b/tests/component/test_simulator.py
@@ -1,13 +1,9 @@
-"""Tests the controller module."""
-import os
-import sys
+"""Tests the controller module using the simulator."""
 import unittest
 import dronekit_sitl
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 import control.controller
 
 
-# TODO: setup() sitl, test arm() function
 class ControllerTest(unittest.TestCase):
     """Tests the controller in charge of the drone itself."""
     def setUp(self):

--- a/tests/unit/test_communication.py
+++ b/tests/unit/test_communication.py
@@ -1,0 +1,26 @@
+"""Tests the communication module."""
+import json
+from mock import patch, call
+import control.communication
+
+
+@patch('serial.Serial')
+def test_receiving_valid_data(mock_serial_class):
+    """Confirm the json data is returned as actual data."""
+    expected = {'test': 5}  # Random data
+    serial_mock = mock_serial_class.return_value
+    serial_mock.readline.return_value = json.dumps(expected)
+    comm = control.communication.Communication('port')
+    actual = comm.receive()
+    assert actual == expected
+
+
+@patch('serial.Serial')
+def test_sending_valid_data(mock_serial_class):
+    """Confirm the jsonned data is passed to pyserial correctly."""
+    serial_mock = mock_serial_class.return_value
+    data = {'test': 5}  # Random data
+    expected_calls = [call(json.dumps(data)), call(b'\n')]
+    comm = control.communication.Communication('port')
+    comm.send(data)
+    serial_mock.write.assert_has_calls(expected_calls)

--- a/tests/unit/test_gps.py
+++ b/tests/unit/test_gps.py
@@ -1,10 +1,7 @@
 """Tests the gps module."""
-import os
-import pynmea2
-import sys
 import unittest
 from mock import patch
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+import pynmea2
 import control.gps
 
 # mock gps nmea 0183 messages

--- a/tests/unit/test_i2cdataclient.py
+++ b/tests/unit/test_i2cdataclient.py
@@ -1,9 +1,6 @@
 """Tests the i2cdataclient module."""
-import os
-import sys
 import unittest
 from mock import patch
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 import control.i2cdataclient
 
 


### PR DESCRIPTION
Added the communication class for use with the Xbee module. Currently
this just sends a json version of whatever data it is given, and
receives a json object and returns the loaded version of that json
object. Some work should be done to make it non-blocking. Some work
should also be done to handle bad transmissions and lost transmissions.
Some basic unit tests confirm functionality of the receive and send
functions.

Added pytest to run all unit tests. This allows us to stop using the
tedious structure of the builtin unittest and provides more options for
parametizing tests in the future. Updated the CI scripts to reflect
this.

Added setup.py to allow the package to be installed as edittable via
pip. This allows us to ditch those annoying path injection lines in the
tests and examples and is a more permanent solution.

Separated tests based on whether they did or did not use the dronekit
simulator. The simulator takes forever to run tests and I found it to be
too slow to make a quick change and have to wait 40 seconds to get the
unit test results. Now you can get results more quickly and just run the
simulator tests every once in a while.

Added flake8 to the CI script. I'd like to use pylint or make flake8 a
little more aggressive in its checks, but I don't feel like configuring
pylint to chill out a bit or flake8 to get meaner.