### PR TITLE
Add gps error handling and coordinate offset calculations

### DIFF
--- a/control/gps.py
+++ b/control/gps.py
@@ -66,13 +66,13 @@ class Gps:
     def read(self):
         """Returns a GpsReading object with the values supplied"""
         msg = None
-        tries = 4
-        for attempt in range(1, tries + 1):
+        max_tries = 4
+        for attempt in range(1, max_tries + 1):
             try:
                 while not isinstance(msg, pynmea2.GGA):
                     msg = pynmea2.parse(self.ser.readline())
             except pynmea2.ParseError:
-                if attempt == tries:
+                if attempt == max_tries:
                     raise GpsReadError('max number of parse attempts reached', attempt)
                 else:
                     pass

--- a/control/gps.py
+++ b/control/gps.py
@@ -34,7 +34,7 @@ class GpsReading:
 class Gps:
     """A class for gathering GPS data via serial"""
     def __init__(self, port, baudrate):
-        self.ser = serial.Serial(port, baudrate)
+        self.ser = serial.Serial(port, baudrate, timeout=1)
 
     def __repr__(self):
         """Returns representation of GPS"""
@@ -44,7 +44,6 @@ class Gps:
         """Returns a GpsReading object with the values supplied"""
         msg = None
         tries = 4
-        # TODO: Add timeout for reads using signal library
         for attempt in range(1, tries + 1):
             try:
                 while not isinstance(msg, pynmea2.GGA):

--- a/control/gps.py
+++ b/control/gps.py
@@ -1,6 +1,29 @@
 """Defines classes used to read and handle GPS data"""
+import math
 import pynmea2
 import serial
+
+
+def get_location_offset(origin, x_offset, y_offset):
+    """
+    Returns a GpsReading with calculated GPS latitude and longitude coordinates given a
+    x and y offset in meters from original GPS coordinates. It keeps the same altitude as
+    original GpsReading and passes in a null timestamp.
+    Sources:
+    https://github.com/dronekit/dronekit-python/blob/master/examples/mission_basic/mission_basic.py
+    http://gis.stackexchange.com/questions/2951/algorithm-for-offsetting-a-latitude-longitude-by-some-amount-of-meters
+    """
+
+    earth_radius = 6378137.0  # Radius of "spherical" earth
+
+    # Offsets coordinates in radians
+    lat_offset = x_offset / earth_radius
+    lon_offset = y_offset / (earth_radius*math.cos(math.pi*origin.latitude/180))
+
+    # New position in decimal degrees
+    new_lat = origin.latitude + (lat_offset * 180/math.pi)
+    new_lon = origin.longitude + (lon_offset * 180/math.pi)
+    return GpsReading(new_lat, new_lon, origin.altitude, 0)
 
 
 class GpsReadError(Exception):


### PR DESCRIPTION
Allowed for multiple read attempts for corrupt data and a serial timeout for lost connections. Also added a helper function to calculate the GPS coordinates based on x and y meter offsets from an original location. This function gives a fairly accurate calculation but could be improved. I couldn't find a python module that already does the calculations that we need. To be more accurate, we'd probably have to convert to another coordinate system such as UTM and provide a grid location based on the starting point on earth. I think for now this will give us close enough coordinates to work as expected.